### PR TITLE
Fixes to allow use of python 2 and 3 and django > 1.8

### DIFF
--- a/freeze/parser.py
+++ b/freeze/parser.py
@@ -51,9 +51,12 @@ def parse_sitemap_urls( site_url = settings.FREEZE_SITE_URL ):
     if sitemap_ok:
         
         sitemap_urls_data = sitemap_data.get('urlset', {}).get('url', {})
-        
+
+        #this happens if the sitemap only has a single entry
+        if 'loc' in sitemap_urls_data:
+            sitemap_urls_data = [sitemap_urls_data]
+
         for sitemap_url_data in sitemap_urls_data:
-            
             url = sitemap_url_data.get('loc', '')
             urls.append(url)
             

--- a/freeze/version.py
+++ b/freeze/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 

--- a/freeze/views.py
+++ b/freeze/views.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from django.core.exceptions import PermissionDenied
-from django.core.servers.basehttp import FileWrapper
+
+from wsgiref.util import FileWrapper
+
 from django.http import HttpResponse
 from django.http import HttpResponseServerError
 from django.http import StreamingHttpResponse

--- a/freeze/writer.py
+++ b/freeze/writer.py
@@ -52,7 +52,13 @@ def write(data, include_media = settings.FREEZE_INCLUDE_MEDIA, include_static = 
         print(u'create file: %s' % (file_path, ))
         
         file_obj = open(file_path, 'wb')
-        file_obj.write(file_data)
+        encoded_file_data = file_data
+        try:
+            encoded_file_data = bytes(file_data, 'utf-8')
+        except TypeError:
+            pass
+
+        file_obj.write(encoded_file_data)
         file_obj.close()
         
         

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup
 
 exec(open('freeze/version.py').read())
 
+from freeze import __version__
 
 setup(
     name='django-freeze',
@@ -18,7 +19,7 @@ setup(
     download_url='https://github.com/fabiocaccamo/django-freeze/archive/%s.tar.gz' % __version__,
     keywords=['django', 'freeze', 'static', 'site', 'generator', 'generate', 'convert', 'export', 'download', 'zip'],
     install_requires=[
-        'Django>=1.6.5,<1.9',
+        'Django>=1.6.5',
         'beautifulsoup4>=4.4.1',
         'requests>=2.8.0',
         'xmltodict>=0.9.2',


### PR DESCRIPTION
These changes have been tested against:
python 2.7 + django 1.7
and 
python 3.5 + django 1.10

One additional small fix was made to fix a bug where a single entry in the sitemap.xml would cause an exception. 