### PR TITLE
adding request headers parameter for GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,12 @@ FREEZE_INCLUDE_STATIC = ('myapp1', 'myapp2', 'myapp3', )
 FREEZE_ZIP_ALL = False
 
 #the name of the zip file created
-FREEZE_ZIP_NAME = 'freeze' 
+FREEZE_ZIP_NAME = 'freeze'
+
+#The request headers to use during the get requests that scrape the site
+#can be used to set Authentication headers, by default sets the user-agent
+FREEZE_REQUEST_HEADERS = {'user-agent': 'django-freeze'}
+
 ```
 Add **freeze.urls** to ``urls.py`` if you want superusers and staff able to use freeze urls.
 
@@ -95,9 +100,6 @@ urlpatterns = patterns('',
     ...
 )
 ```
-#The request headers to use during the get requests that scrape the site
-#can be used to set Authentication headers, by default sets the user-agent
-FREEZE_REQUEST_HEADERS = {'user-agent': 'django-freeze'}
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ urlpatterns = patterns('',
     ...
 )
 ```
+#The request headers to use during the get requests that scrape the site
+#can be used to set Authentication headers, by default sets the user-agent
+FREEZE_REQUEST_HEADERS = {'user-agent': 'django-freeze'}
 
 ## Usage
 

--- a/freeze/scanner.py
+++ b/freeze/scanner.py
@@ -9,7 +9,7 @@ import requests
 from freeze import settings, parser
 
 
-def scan( site_url = settings.FREEZE_SITE_URL, base_url = settings.FREEZE_BASE_URL, relative_urls = settings.FREEZE_RELATIVE_URLS, local_urls = settings.FREEZE_LOCAL_URLS, follow_sitemap_urls = settings.FREEZE_FOLLOW_SITEMAP_URLS, follow_html_urls = settings.FREEZE_FOLLOW_HTML_URLS, report_invalid_urls = settings.FREEZE_REPORT_INVALID_URLS ):
+def scan( site_url = settings.FREEZE_SITE_URL, base_url = settings.FREEZE_BASE_URL, relative_urls = settings.FREEZE_RELATIVE_URLS, local_urls = settings.FREEZE_LOCAL_URLS, follow_sitemap_urls = settings.FREEZE_FOLLOW_SITEMAP_URLS, follow_html_urls = settings.FREEZE_FOLLOW_HTML_URLS, report_invalid_urls = settings.FREEZE_REPORT_INVALID_URLS, request_headers = settings.FREEZE_REQUEST_HEADERS ):
     
     if site_url.endswith('/'):
         site_url = site_url[0:-1]
@@ -60,7 +60,7 @@ def scan( site_url = settings.FREEZE_SITE_URL, base_url = settings.FREEZE_BASE_U
             
         print(u'\nfetch url: %s' % (url, ))
         
-        req = requests.get(url)
+        req = requests.get(url, headers=request_headers)
         req.encoding = 'utf-8'
         
         if req.status_code == requests.codes.ok:

--- a/freeze/settings.py
+++ b/freeze/settings.py
@@ -65,4 +65,4 @@ if len(FREEZE_ZIP_NAME) >= 4 and FREEZE_ZIP_NAME[-4:].lower() != '.zip':
 
 FREEZE_ZIP_PATH = os.path.abspath(os.path.join(FREEZE_ROOT, FREEZE_ZIP_NAME))
 
-FREEZE_REQUEST_HEADERS = {'user-agent': 'django-freeze'}
+FREEZE_REQUEST_HEADERS = getattr(settings, 'FREEZE_REQUEST_HEADERS', {'user-agent': 'django-freeze'})

--- a/freeze/settings.py
+++ b/freeze/settings.py
@@ -65,3 +65,4 @@ if len(FREEZE_ZIP_NAME) >= 4 and FREEZE_ZIP_NAME[-4:].lower() != '.zip':
 
 FREEZE_ZIP_PATH = os.path.abspath(os.path.join(FREEZE_ROOT, FREEZE_ZIP_NAME))
 
+FREEZE_REQUEST_HEADERS = {'user-agent': 'django-freeze'}

--- a/freeze/version.py
+++ b/freeze/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 


### PR DESCRIPTION
By default the request headers include a `user-agent: django-freeze`, which is a nice way to identify in access logs if requests are coming from django-freeze. 

An additional benefit of allowing the headers to be configured is that an authentication token or basic authentication can be added.

ie. 
```
import base64
FREEZE_REQUEST_HEADERS = {'user-agent': 'django-freeze',
                          'Authorization': 'Basic {}'.format(
                              base64.b64encode(bytes('user:password', 'UTF-8')).decode('UTF-8')
                          )}
```