### PR TITLE
Add classifiers to setup.py to indicate support for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,15 @@ setup(
         'requests>=2.8.0',
         'xmltodict>=0.9.2',
     ],
-    classifiers=[]
+    classifiers=[
+        'Framework :: Django',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python',
+    ],
 )
 


### PR DESCRIPTION
This is the best way to show that the package is Python 3 compatible.

For instance, this page incorrectly lists this package as incompatible with Python 3: https://djangopackages.org/packages/p/django-freeze/