### PR TITLE
Small change in settings file to allow settings to be loaded without a running Database

### DIFF
--- a/freeze/settings.py
+++ b/freeze/settings.py
@@ -22,10 +22,13 @@ FREEZE_STATIC_ROOT = settings.STATIC_ROOT
 FREEZE_STATIC_URL = settings.STATIC_URL
 
 FREEZE_USE_HTTPS = getattr(settings, 'FREEZE_USE_HTTPS', False)
-FREEZE_SITE = Site.objects.get_current()
 FREEZE_PROTOCOL = 'https://' if FREEZE_USE_HTTPS else 'http://'
-FREEZE_DOMAIN = FREEZE_SITE.domain
-FREEZE_SITE_URL = getattr(settings, 'FREEZE_SITE_URL', '%s%s' % (FREEZE_PROTOCOL, FREEZE_DOMAIN, ))
+FREEZE_SITE_URL = getattr(settings, 'FREEZE_SITE_URL', None)
+if(FREEZE_SITE_URL == None):
+    # handled this way to remove DB dependency unless strictly needed.  If FREEZE_SITE_URL is set then collectstatic
+    # can be called without needing a db setup, which is useful for build servers
+    FREEZE_SITE_URL = '%s%s' % (FREEZE_PROTOCOL, Site.objects.get_current().domain,)
+
 
 FREEZE_BASE_URL = getattr(settings, 'FREEZE_BASE_URL', None)
 

--- a/freeze/version.py
+++ b/freeze/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 


### PR DESCRIPTION
I ran into this issue running the collectstatic command on a build server that doesn't have a database setup. 

The change is to only hit the database for FREEZE_SITE_URL only if FREEZE_SITE_URL not set by the user.